### PR TITLE
Pr367 - lookahead with `get_committee_assignment`

### DIFF
--- a/eth2/beacon/state_machines/forks/serenity/block_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_processing.py
@@ -69,6 +69,7 @@ def process_randao(state: BeaconState,
 
     validate_randao_reveal(
         randao_reveal=block.randao_reveal,
+        proposer_index=proposer_index,
         proposer_pubkey=proposer.pubkey,
         epoch=epoch,
         fork=state.fork,

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -605,6 +605,7 @@ def validate_attestation_aggregate_signature(state: BeaconState,
 
 
 def validate_randao_reveal(randao_reveal: BLSSignature,
+                           proposer_index: ValidatorIndex,
                            proposer_pubkey: BLSPubkey,
                            epoch: Epoch,
                            fork: Fork) -> None:
@@ -621,8 +622,9 @@ def validate_randao_reveal(randao_reveal: BLSSignature,
     if not is_randao_reveal_valid:
         raise ValidationError(
             f"RANDAO reveal is invalid. "
-            f"reveal={randao_reveal}, proposer_pubkey={proposer_pubkey}, "
-            f"message_hash={message_hash}, domain={domain}"
+            f"proposer_index={proposer_index}, proposer_pubkey={proposer_pubkey}, "
+            f"reveal={randao_reveal}, "
+            f"message_hash={message_hash}, domain={domain}, epoch={epoch}"
         )
 
 

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -1035,7 +1035,7 @@ def process_final_updates(state: BeaconState,
         ),
         latest_randao_mixes=update_tuple_item(
             state.latest_randao_mixes,
-            next_epoch % config.LATEST_SLASHED_EXIT_LENGTH,
+            next_epoch % config.LATEST_RANDAO_MIXES_LENGTH,
             get_randao_mix(
                 state=state,
                 epoch=current_epoch,

--- a/eth2/beacon/tools/builder/proposer.py
+++ b/eth2/beacon/tools/builder/proposer.py
@@ -44,6 +44,7 @@ from eth2.beacon.typing import (
 )
 
 from eth2.beacon.tools.builder.validator import (
+    get_committee_assignment,
     sign_transaction,
 )
 
@@ -184,7 +185,26 @@ def create_mock_block(*,
 
     Note that it doesn't return the correct ``state_root``.
     """
-    proposer_index = _get_proposer_index(state_machine, state, slot, parent_block.root, config)
+    epoch = slot_to_epoch(slot, config.SLOTS_PER_EPOCH)
+
+    # Lookahead
+    # TODO: set registry_change to True if there's any registry change.
+    # TODO: Lookahead can be done within on call for the epoch, before calling `create_mock_block`.
+    registry_change = False
+    for index in range(state.validator_registry):
+        index = ValidatorIndex(index)
+        assignment = get_committee_assignment(
+            state,
+            config,
+            epoch,
+            index,
+            registry_change=registry_change,
+        )
+        if assignment.is_proposer:
+            if assignment.slot == slot:
+                proposer_index = index
+                break
+
     proposer_pubkey = state.validator_registry[proposer_index].pubkey
     proposer_privkey = keymap[proposer_pubkey]
 


### PR DESCRIPTION
### What was wrong?

Theoretically, we should be able to use `get_committee_assignment` to perform lookahead for real case, so that the validators can know if they are the proposer at least one epoch ahead.

There are some bugfixes from the spec side around lookahead this week, now Trinity has synced it, but hope that there's no other problem... 😬  


### How was it fixed?

1. Use `_generate_randao_reveal` in `test_randao_processing`
2. bugfix: use `LATEST_RANDAO_MIXES_LENGTH` instead of `LATEST_SLASHED_EXIT_LENGTH`
3. Add more debugging info when `ValidatorError` in randao reveal
4. Use `get_committee_assignment` for lookahead

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
